### PR TITLE
Geofence input fix resolved #65

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -74,7 +74,7 @@ public class RobotContainer
                 || s_Intake.getCoralState() && (s_Diffector.getEncoderPos() > 45 && s_Diffector.getEncoderPos() < 315) ||
                 s_Intake.getAlgaeState() && (s_Diffector.getEncoderPos() > 135 && s_Diffector.getEncoderPos() < 225));
     //private final Trigger driverRightRumblTrigger = new Trigger(() -> )
-    // TODO: Read y to score rumble
+    // TODO: Ready to score rumble
     private final Trigger copliotRightRumbleTrigger = new Trigger(() -> s_Intake.climbReady() && s_Climber.climbReady() && s_Diffector.climbReady() );
 
     /** The container for the robot. Contains subsystems, OI devices, and commands. */

--- a/src/main/java/frc/robot/commands/Auto/TargetHeading.java
+++ b/src/main/java/frc/robot/commands/Auto/TargetHeading.java
@@ -33,7 +33,8 @@ public class TargetHeading extends Command
   private DoubleSupplier brakeSup;
   private BooleanSupplier fencedSup;
   private Translation2d motionXY;
-  private final GeoFenceObject[] fieldGeoFence = FieldUtils.GeoFencing.fieldGeoFence;
+  private GeoFenceObject[] fieldGeoFence;
+  private boolean redAlliance;
   private double robotRadius;
   private double robotSpeed;
 
@@ -55,6 +56,17 @@ public class TargetHeading extends Command
     this.targetHeading = targetHeading;
 
     driveRequest.HeadingController.setPID(Constants.Swerve.rotationKP, Constants.Swerve.rotationKI, Constants.Swerve.rotationKD);
+  }
+
+  @Override
+  public void initialize()
+  {
+    redAlliance = FieldUtils.isRedAlliance();
+    SmartDashboard.putBoolean("redAlliance", redAlliance);
+    if (redAlliance)
+      {fieldGeoFence = FieldUtils.GeoFencing.fieldRedGeoFence;}
+    else
+      {fieldGeoFence = FieldUtils.GeoFencing.fieldBlueGeoFence;}
   }
 
   // Called every time the scheduler runs while the command is scheduled.
@@ -80,13 +92,23 @@ public class TargetHeading extends Command
       {
           robotRadius = FieldUtils.GeoFencing.robotRadiusInscribed;
       }
+      
+      // Invert processing input when on red alliance
+      if (redAlliance)
+        {motionXY = motionXY.unaryMinus();}
+
       // Read down the list of geofence objects
       // Outer wall is index 0, so has highest authority by being processed last
-      for (int i = fieldGeoFence.length - 1; i >= 0; i--)
+      for (int i = fieldGeoFence.length - 1; i >= 0; i--) // ERROR: Stick input seems to have been inverted for the new swerve library, verify and impliment a better fix
       {
-          Translation2d inputDamping = fieldGeoFence[i].dampMotion(s_Swerve.getState().Pose.getTranslation(), motionXY, robotRadius);
-          motionXY = inputDamping;
+        Translation2d inputDamping = fieldGeoFence[i].dampMotion(s_Swerve.getState().Pose.getTranslation(), motionXY, robotRadius);
+        motionXY = inputDamping;
       }
+
+      // Uninvert processing output when on red alliance
+      if (redAlliance)
+        {motionXY = motionXY.unaryMinus();}
+        
       s_Swerve.setControl
       (
           driveRequest

--- a/src/main/java/frc/robot/commands/Auto/TargetHeadingStation.java
+++ b/src/main/java/frc/robot/commands/Auto/TargetHeadingStation.java
@@ -35,7 +35,8 @@ public class TargetHeadingStation extends Command
   private BooleanSupplier fencedSup;
   private Translation2d motionXY;
   private DoubleSupplier ySup;
-  private final GeoFenceObject[] fieldGeoFence = FieldUtils.GeoFencing.fieldGeoFence;
+  private GeoFenceObject[] fieldGeoFence;
+  private boolean redAlliance;
   private double robotRadius;
   private double robotSpeed;
 
@@ -62,10 +63,16 @@ public class TargetHeadingStation extends Command
     driveRequest.HeadingController.setPID(Constants.Swerve.rotationKP, Constants.Swerve.rotationKI, Constants.Swerve.rotationKD);
   }
 
-  @Override 
+  @Override
   public void initialize()
   {
     updateTargetHeading();
+    redAlliance = FieldUtils.isRedAlliance();
+    SmartDashboard.putBoolean("redAlliance", redAlliance);
+    if (redAlliance)
+      {fieldGeoFence = FieldUtils.GeoFencing.fieldRedGeoFence;}
+    else
+      {fieldGeoFence = FieldUtils.GeoFencing.fieldBlueGeoFence;}
   }
 
   // Called every time the scheduler runs while the command is scheduled.
@@ -90,25 +97,35 @@ public class TargetHeadingStation extends Command
       SmartDashboard.putString("Drive State", "Fenced");
       if (robotSpeed >= FieldUtils.GeoFencing.robotSpeedThreshold)
       {
-          robotRadius = FieldUtils.GeoFencing.robotRadiusCircumscribed;
+        robotRadius = FieldUtils.GeoFencing.robotRadiusCircumscribed;
       }
       else
       {
-          robotRadius = FieldUtils.GeoFencing.robotRadiusInscribed;
+        robotRadius = FieldUtils.GeoFencing.robotRadiusInscribed;
       }
+      
+      // Invert processing input when on red alliance
+      if (redAlliance)
+        {motionXY = motionXY.unaryMinus();}
+
       // Read down the list of geofence objects
       // Outer wall is index 0, so has highest authority by being processed last
-      for (int i = fieldGeoFence.length - 1; i >= 0; i--)
+      for (int i = fieldGeoFence.length - 1; i >= 0; i--) // ERROR: Stick input seems to have been inverted for the new swerve library, verify and impliment a better fix
       {
-          Translation2d inputDamping = fieldGeoFence[i].dampMotion(s_Swerve.getState().Pose.getTranslation(), motionXY, robotRadius);
-          motionXY = inputDamping;
+        Translation2d inputDamping = fieldGeoFence[i].dampMotion(s_Swerve.getState().Pose.getTranslation(), motionXY, robotRadius);
+        motionXY = inputDamping;
       }
+
+      // Uninvert processing output when on red alliance
+      if (redAlliance)
+        {motionXY = motionXY.unaryMinus();}
+
       s_Swerve.setControl
       (
-          driveRequest
-          .withVelocityX(motionXY.getX())
-          .withVelocityY(motionXY.getY())
-          .withTargetDirection(targetHeading)
+        driveRequest
+        .withVelocityX(motionXY.getX())
+        .withVelocityY(motionXY.getY())
+        .withTargetDirection(targetHeading)
       );
     }
     else

--- a/src/main/java/frc/robot/commands/TeleopSwerve.java
+++ b/src/main/java/frc/robot/commands/TeleopSwerve.java
@@ -17,12 +17,15 @@ import edu.wpi.first.wpilibj2.command.Command;
 
 public class TeleopSwerve extends Command 
 {    
-    private final SwerveRequest.FieldCentric driveRequest = new SwerveRequest.FieldCentric()
+    private final SwerveRequest.FieldCentric driveRequest = new SwerveRequest
+        .FieldCentric()
         .withDeadband(Constants.Control.maxThrottle * Constants.Swerve.maxSpeed * Constants.Control.stickDeadband)
         .withRotationalDeadband(Constants.Swerve.maxAngularVelocity * Constants.Control.stickDeadband)
         .withDriveRequestType(com.ctre.phoenix6.swerve.SwerveModule.DriveRequestType.OpenLoopVoltage)
         .withSteerRequestType(SteerRequestType.MotionMagicExpo);
-    private final SwerveRequest.RobotCentric driveRequestRoboCentric = new SwerveRequest.RobotCentric()
+
+    private final SwerveRequest.RobotCentric driveRequestRoboCentric = new SwerveRequest
+        .RobotCentric()
         .withDeadband(Constants.Control.maxThrottle * Constants.Swerve.maxSpeed * Constants.Control.stickDeadband)
         .withRotationalDeadband(Constants.Swerve.maxAngularVelocity * Constants.Control.stickDeadband)
         .withDriveRequestType(com.ctre.phoenix6.swerve.SwerveModule.DriveRequestType.OpenLoopVoltage)
@@ -75,23 +78,23 @@ public class TeleopSwerve extends Command
         {
             if (fencedSup.getAsBoolean())
             {
-                robotSpeed = Math.hypot(s_Swerve.getState().Speeds.vxMetersPerSecond, s_Swerve.getState().Speeds.vyMetersPerSecond);
                 SmartDashboard.putString("Drive State", "Fenced");
+                SmartDashboard.putString("XY in:", motionXY.toString());
+
+                robotSpeed = Math.hypot(s_Swerve.getState().Speeds.vxMetersPerSecond, s_Swerve.getState().Speeds.vyMetersPerSecond);
                 if (robotSpeed >= FieldUtils.GeoFencing.robotSpeedThreshold)
-                {
-                    robotRadius = FieldUtils.GeoFencing.robotRadiusCircumscribed;
-                }
+                    {robotRadius = FieldUtils.GeoFencing.robotRadiusCircumscribed;}
                 else
-                {
-                    robotRadius = FieldUtils.GeoFencing.robotRadiusInscribed;
-                }
+                    {robotRadius = FieldUtils.GeoFencing.robotRadiusInscribed;}
+                
                 // Read down the list of geofence objects
                 // Outer wall is index 0, so has highest authority by being processed last
                 for (int i = fieldGeoFence.length - 1; i >= 0; i--) // ERROR: Stick input seems to have been inverted for the new swerve library, verify and impliment a better fix
                 {
-                    Translation2d inputDamping = fieldGeoFence[i].dampMotion(s_Swerve.getState().Pose.getTranslation(), motionXY.unaryMinus(), robotRadius);
-                    motionXY = inputDamping.unaryMinus();
+                    Translation2d inputDamping = fieldGeoFence[i].dampMotion(s_Swerve.getState().Pose.getTranslation(), motionXY, robotRadius);
+                    motionXY = inputDamping;
                 }
+                SmartDashboard.putString("XY out:", motionXY.toString());
                 s_Swerve.setControl
                 (
                     driveRequest
@@ -114,7 +117,7 @@ public class TeleopSwerve extends Command
         }
         else
         {
-            SmartDashboard.putString("Drive State", "Robot-Rel");
+            SmartDashboard.putString("Drive State", "Robot-Relative");
             s_Swerve.setControl
             (
                 driveRequestRoboCentric

--- a/src/main/java/frc/robot/constants/TunerConstants.java
+++ b/src/main/java/frc/robot/constants/TunerConstants.java
@@ -87,7 +87,7 @@ public class TunerConstants {
     private static final boolean kInvertLeftSide = false;
     private static final boolean kInvertRightSide = true;
 
-    private static final int kPigeonId = 5;
+    private static final int kPigeonId = IDConstants.pigeonID;
 
     // These are only used for simulation
     private static final MomentOfInertia kSteerInertia = KilogramSquareMeters.of(0.01);

--- a/src/main/java/frc/robot/util/FieldUtils.java
+++ b/src/main/java/frc/robot/util/FieldUtils.java
@@ -84,7 +84,7 @@ public class FieldUtils
         public static final double fieldEast = fieldLength;
 
         /** Metres the robot can travel back */
-        public static final double fieldWest = 1;
+        public static final double fieldWest = 0;
 
         /** Buffer zone for the field walls in metres */
         public static final double wallBuffer = 0.5;
@@ -97,18 +97,18 @@ public class FieldUtils
         public static final double circumscribedReefZoneDiameter = 2.742;
         
         /** Buffer zone for the reef in metres */
-        public static final double reefBuffer = 0.25;
+        public static final double reefBuffer = 0.5;
 
         /** Buffer zone for the barge zone in metres */
-        public static final double bargeBuffer = 0.25;
+        public static final double bargeBuffer = 0.5;
 
         public static final double cornerWidth  = 1.276;
         public static final double cornerLength = 1.758;
 
         public static final GeoFenceObject field = new GeoFenceObject
         (
-            -fieldWest, 
-            -fieldSouth, 
+            fieldWest, 
+            fieldSouth, 
             fieldEast, 
             fieldNorth, 
             wallBuffer,
@@ -116,24 +116,38 @@ public class FieldUtils
             ObjectTypes.walls
         );
 
-        public static final GeoFenceObject reefBlue = new GeoFenceObject(4.489, 4.026, reefBuffer, circumscribedReefDiameter / 2, 0, 6); // TODO: set as reef zone for testing
-        public static final GeoFenceObject reefRed = new GeoFenceObject(13.059, 4.026, reefBuffer, circumscribedReefDiameter / 2, 180, 6);
-        public static final GeoFenceObject bargeColumn = new GeoFenceObject(8.774, 4.026, 0.25, 0.15);
-        public static final GeoFenceObject bargeZoneBlue = new GeoFenceObject(8.190, 3.721, 9.358, 0, bargeBuffer, 0, ObjectTypes.box);
-        public static final GeoFenceObject bargeZoneRed = new GeoFenceObject(8.190, 4.331, 9.358, fieldWidth, bargeBuffer, 0, ObjectTypes.box);
-        public static final GeoFenceObject cornerSBlue = new GeoFenceObject(fieldWest, fieldSouth + cornerWidth, fieldWest + cornerLength, fieldSouth, wallBuffer);
-        public static final GeoFenceObject cornerNBlue = new GeoFenceObject(fieldWest, fieldNorth - cornerWidth, fieldWest + cornerLength, fieldNorth, wallBuffer);
-        public static final GeoFenceObject cornerSRed = new GeoFenceObject(fieldEast, fieldSouth + cornerWidth, fieldEast - cornerLength, fieldSouth, wallBuffer);
-        public static final GeoFenceObject cornerNRed = new GeoFenceObject(fieldEast, fieldNorth - cornerWidth, fieldEast - cornerLength, fieldNorth, wallBuffer);
+        public static final GeoFenceObject reefBlue      = new GeoFenceObject(4.489, 4.026, reefBuffer, circumscribedReefDiameter / 2, 0, 6);
+        public static final GeoFenceObject reefZoneBlue  = new GeoFenceObject(4.489, 4.026, reefBuffer, circumscribedReefZoneDiameter / 2, 0, 6);
+        public static final GeoFenceObject reefRed       = new GeoFenceObject(13.059, 4.026, reefBuffer, circumscribedReefDiameter / 2, 180, 6);
+        public static final GeoFenceObject reefZoneRed   = new GeoFenceObject(13.059, 4.026, reefBuffer, circumscribedReefZoneDiameter / 2, 180, 6);
+        public static final GeoFenceObject bargeColumn   = new GeoFenceObject(8.774, 4.026, 0.25, 0.15);
+        public static final GeoFenceObject bargeZoneBlue = new GeoFenceObject(8.190, 4.331, 9.358, fieldWidth, bargeBuffer, 0.1, ObjectTypes.box);
+        public static final GeoFenceObject bargeZoneRed  = new GeoFenceObject(8.190, 3.721, 9.358, 0, bargeBuffer, 0.1, ObjectTypes.box);
+        public static final GeoFenceObject cornerSBlue   = new GeoFenceObject(fieldWest, fieldSouth + cornerWidth, fieldWest + cornerLength, fieldSouth, wallBuffer);
+        public static final GeoFenceObject cornerNBlue   = new GeoFenceObject(fieldWest, fieldNorth - cornerWidth, fieldWest + cornerLength, fieldNorth, wallBuffer);
+        public static final GeoFenceObject cornerSRed    = new GeoFenceObject(fieldEast, fieldSouth + cornerWidth, fieldEast - cornerLength, fieldSouth, wallBuffer);
+        public static final GeoFenceObject cornerNRed    = new GeoFenceObject(fieldEast, fieldNorth - cornerWidth, fieldEast - cornerLength, fieldNorth, wallBuffer);
 
-        public static final GeoFenceObject[] fieldGeoFence = 
+        public static final GeoFenceObject[] fieldBlueGeoFence = 
         {
             field, 
             reefBlue, 
+            reefZoneRed, 
+            bargeColumn, 
+            bargeZoneRed, 
+            cornerSBlue, 
+            cornerNBlue, 
+            cornerSRed, 
+            cornerNRed
+        };
+
+        public static final GeoFenceObject[] fieldRedGeoFence = 
+        {
+            field, 
             reefRed, 
+            reefZoneBlue, 
             bargeColumn, 
             bargeZoneBlue, 
-            bargeZoneRed, 
             cornerSBlue, 
             cornerNBlue, 
             cornerSRed, 

--- a/src/main/java/frc/robot/util/GeoFenceObject.java
+++ b/src/main/java/frc/robot/util/GeoFenceObject.java
@@ -323,7 +323,7 @@ public class GeoFenceObject
                     }
                     else // W Cardinal
                     {
-                        distanceToEdgeX = Math.abs((Xa - radius) - (robotXY.getX() + robotR)); 
+                        distanceToEdgeX = (Xa - radius) - (robotXY.getX() + robotR);
                         motionX = Math.min(motionX, (Conversions.clamp(distanceToEdgeX, 0, buffer)) / buffer);
                     }
                 }
@@ -339,7 +339,7 @@ public class GeoFenceObject
                     }
                     else // E Cardinal
                     {
-                        distanceToEdgeX = Math.abs((robotXY.getX() - robotR) - (Xb + radius));
+                        distanceToEdgeX = (robotXY.getX() - robotR) - (Xb + radius);
                         motionX = Math.max(motionX, (-Conversions.clamp(distanceToEdgeX, 0, buffer)) / buffer);
                     }
                 }
@@ -347,12 +347,12 @@ public class GeoFenceObject
                 {
                     if (robotXY.getY() < Ya) // S Cardinal
                     {
-                        distanceToEdgeY = Math.abs((Ya - radius) - (robotXY.getY() + robotR));
+                        distanceToEdgeY = (Ya - radius) - (robotXY.getY() + robotR);
                         motionY = Math.min(motionY, (Conversions.clamp(distanceToEdgeY, 0, buffer)) / buffer);
                     } 
                     else if (robotXY.getY() > Yb) // N Cardinal
                     {
-                        distanceToEdgeY = Math.abs((robotXY.getY() - robotR) - (Yb + radius));
+                        distanceToEdgeY = (robotXY.getY() - robotR) - (Yb + radius);
                         motionY = Math.max(motionY, (-Conversions.clamp(distanceToEdgeY, 0, buffer)) / buffer);
                     }
                     else // Center (you've met a terrible fate *insert kazoo music here*)


### PR DESCRIPTION
Issue was that stick input was being inverted for red alliance going into the swerve system, but after geofencing.

Stick input is now inverted going into and out of geofencing if on red alliance.
Should find a better way to implement the fix, but I don't want to touch the CTRE swerve at this point.

Other geofencing issues are also resolved