### PR TITLE
Geofence line fix

### DIFF
--- a/src/main/java/frc/robot/subsystems/Climber.java
+++ b/src/main/java/frc/robot/subsystems/Climber.java
@@ -13,6 +13,7 @@ import frc.robot.constants.Constants.ClimberConstants;
 import frc.robot.constants.Constants.Control;
 import frc.robot.constants.IDConstants;
 import frc.robot.constants.MechanismConstants.ClimberConfigs;
+import frc.robot.util.Conversions;
 import frc.robot.util.SD;
 
 public class Climber extends SubsystemBase
@@ -118,7 +119,7 @@ public class Climber extends SubsystemBase
           if (SD.OVERRIDE.get()) 
           {
             adjustedClimberPos += RobotContainer.s_Swerve.getPigeon2().getPitch().getValueAsDouble() * ClimberConfigs.winchBalanceScalar;
-            adjustedClimberPos = MathUtil.clamp(adjustedClimberPos, ClimberConstants.climbActiveInnerLimit, ClimberConstants.climbActiveOuterLimit);
+            adjustedClimberPos = Conversions.clamp(adjustedClimberPos, ClimberConstants.climbActiveInnerLimit, ClimberConstants.climbActiveOuterLimit);
           }
 
           m_Climber.setControl(motionMagic.withPosition(adjustedClimberPos));

--- a/src/main/java/frc/robot/util/Conversions.java
+++ b/src/main/java/frc/robot/util/Conversions.java
@@ -1,5 +1,7 @@
 package frc.robot.util;
 
+import edu.wpi.first.math.MathUtil;
+
 public class Conversions 
 {
   /**
@@ -29,4 +31,28 @@ public class Conversions
     }
     return  value;
   }
+
+  /** 
+   * MathUtil clamp, but allowing for limits to be in any order 
+   * @param value Input value
+   * @param a Maximum or minimum limit
+   * @param b Maximum or minimum limit
+   * @return Input value clamped between a and b
+  */
+  public static int clamp(int value, int a, int b)
+    {return MathUtil.clamp(value, Math.min(a,b), Math.max(a,b));}
+  
+  /** 
+   * MathUtil clamp, but allowing for limits to be in any order 
+   * @param value Input value
+   * @param a Maximum or minimum limit
+   * @param b Maximum or minimum limit
+   * @return Input value clamped between a and b
+  */
+  public static double clamp(double value, double a, double b)
+    {return MathUtil.clamp(value, Math.min(a,b), Math.max(a,b));}
+
+  /** MathUtil clamp [-1..1] */
+  public static double clamp(double value)
+    {return MathUtil.clamp(value, -1, 1);}
 }

--- a/src/main/java/frc/robot/util/GeoFenceObject.java
+++ b/src/main/java/frc/robot/util/GeoFenceObject.java
@@ -140,7 +140,7 @@ public class GeoFenceObject
     buffer = Math.max(buffer, 0.1);
     radius = Math.abs(radius);
     objectType = ObjectTypes.polygon;
-    sides = MathUtil.clamp(sides, 3, 12);
+    sides = Conversions.clamp(sides, 3, 12);
     
     // Array of all points to construct the polygon lines and references
     // The start of the first line and end of the last line are separate enteries to simplify construction
@@ -236,13 +236,12 @@ public class GeoFenceObject
     // Sets maximum input towards the object as:
     //      (position within the buffer normalised to [0..1])   *   (angle normalisation factor [1..sqrt(2)])
     //         (dNormal - object radii)[0..buffer] / buffer     *      (mNormal / max(|X|,|Y|))
-    motionN = Math.min(motionN, motionN * MathUtil.clamp(distanceN-(robotR + radius), 0, buffer)
+    motionN = Math.min(motionN, motionN * Conversions.clamp(distanceN-(robotR + radius), 0, buffer)
                                     / (Math.max(Math.abs(distanceX),Math.abs(distanceY)) * buffer));
     
     // Converts clamped motion from normal back to X and Y
     double motionX   = ((motionN * distanceX) - (motionT * distanceY)) / distanceN;
     double motionY   = ((motionN * distanceY) + (motionT * distanceX)) / distanceN;
-
     return new Translation2d(motionX, motionY);
   }
 
@@ -276,7 +275,7 @@ public class GeoFenceObject
         distanceToEdgeX = robotXY.getX() - Xa;
         distanceToEdgeY = robotXY.getY() - Ya;
         double dot = ((distanceToEdgeX * dXab) + (distanceToEdgeY * dYab)) / dot2ab; // Normalised dot product of the two lines
-        return robotXY.getDistance(new Translation2d(MathUtil.clamp(Xa + dXab * dot, Xa, Xb), MathUtil.clamp(Ya + dYab * dot, Ya, Yb)));
+        return robotXY.getDistance(new Translation2d(Conversions.clamp(Xa + dXab * dot, Xa, Xb), Conversions.clamp(Ya + dYab * dot, Ya, Yb)));
     
       case point:
         return robotXY.getDistance(centre);
@@ -359,7 +358,7 @@ public class GeoFenceObject
         distanceToEdgeX = robotXY.getX() - Xa;
         distanceToEdgeY = robotXY.getY() - Ya;
         double dot = ((distanceToEdgeX * dXab) + (distanceToEdgeY * dYab)) / dot2ab; // Normalised dot product of the two lines
-        return pointDamping(MathUtil.clamp(Xa + dXab * dot, Xa, Xb), MathUtil.clamp(Ya + dYab * dot, Ya, Yb), motionXY, robotR, robotXY);
+        return pointDamping(Conversions.clamp(Xa + dXab * dot, Xa, Xb), Conversions.clamp(Ya + dYab * dot, Ya, Yb), motionXY, robotR, robotXY);
 
       case box:
         if (robotXY.getX() < Xa)
@@ -371,7 +370,7 @@ public class GeoFenceObject
           else // W Cardinal
           {
             distanceToEdgeX = (Xa - radius) - (robotXY.getX() + robotR);
-            motionX = Math.min(motionX, (MathUtil.clamp(distanceToEdgeX, 0, buffer)) / buffer);
+            motionX = Math.min(motionX, (Conversions.clamp(distanceToEdgeX, 0, buffer)) / buffer);
           }
         }
         else if (robotXY.getX() > Xb)
@@ -383,7 +382,7 @@ public class GeoFenceObject
           else // E Cardinal
           {
             distanceToEdgeX = (robotXY.getX() - robotR) - (Xb + radius);
-            motionX = Math.max(motionX, (-MathUtil.clamp(distanceToEdgeX, 0, buffer)) / buffer);
+            motionX = Math.max(motionX, (-Conversions.clamp(distanceToEdgeX, 0, buffer)) / buffer);
           }
         }
         else 
@@ -391,12 +390,12 @@ public class GeoFenceObject
           if (robotXY.getY() < Ya) // S Cardinal
           {
             distanceToEdgeY = (Ya - radius) - (robotXY.getY() + robotR);
-            motionY = Math.min(motionY, (MathUtil.clamp(distanceToEdgeY, 0, buffer)) / buffer);
+            motionY = Math.min(motionY, (Conversions.clamp(distanceToEdgeY, 0, buffer)) / buffer);
           } 
           else if (robotXY.getY() > Yb) // N Cardinal
           {
             distanceToEdgeY = (robotXY.getY() - robotR) - (Yb + radius);
-            motionY = Math.max(motionY, (-MathUtil.clamp(distanceToEdgeY, 0, buffer)) / buffer);
+            motionY = Math.max(motionY, (-Conversions.clamp(distanceToEdgeY, 0, buffer)) / buffer);
           }
           else // Center (you've met a terrible fate *insert kazoo music here*)
             {return pointDamping(centre, motionXY, robotR, robotXY);}
@@ -413,23 +412,23 @@ public class GeoFenceObject
         if (motionX > 0)
         {   
           distanceToEdgeX = (Xb - radius) - (robotXY.getX() + robotR); 
-          motionX = Math.min(motionX, (MathUtil.clamp(distanceToEdgeX, 0, buffer)) / buffer);
+          motionX = Math.min(motionX, (Conversions.clamp(distanceToEdgeX, 0, buffer)) / buffer);
         }
         else if (motionX < 0)
         {   
           distanceToEdgeX = (robotXY.getX() - robotR) - (Xa + radius);
-          motionX = Math.max(motionX, (-MathUtil.clamp(distanceToEdgeX, 0, buffer)) / buffer);
+          motionX = Math.max(motionX, (-Conversions.clamp(distanceToEdgeX, 0, buffer)) / buffer);
         }
 
         if (motionY > 0)
         {   
           distanceToEdgeY = (Yb - radius) - (robotXY.getY() + robotR);
-          motionY = Math.min(motionY, (MathUtil.clamp(distanceToEdgeY, 0, buffer)) / buffer);
+          motionY = Math.min(motionY, (Conversions.clamp(distanceToEdgeY, 0, buffer)) / buffer);
         }
         else if (motionY < 0)
         {   
           distanceToEdgeY = (robotXY.getY() - robotR) - (Ya + radius);
-          motionY = Math.max(motionY, (-MathUtil.clamp(distanceToEdgeY, 0, buffer)) / buffer);
+          motionY = Math.max(motionY, (-Conversions.clamp(distanceToEdgeY, 0, buffer)) / buffer);
         }
         return new Translation2d(motionX, motionY);
     


### PR DESCRIPTION
Line type objects intentionally have the points in any order, and MathUtil.clamp requires that the limits be in the correct order, so the previous change away from Conversions.clamp unexpectedly broke line objects